### PR TITLE
Fix version file syntax

### DIFF
--- a/Distribution/GameData/BDALoadedVesselSwitcher/BDALoadedVesselSwitcher.version
+++ b/Distribution/GameData/BDALoadedVesselSwitcher/BDALoadedVesselSwitcher.version
@@ -7,7 +7,7 @@
     "MAJOR": 1, 
     "MINOR": 1,
     "PATCH": 4,
-	  "BUILD": 0
+    "BUILD": 0
   },
   "KSP_VERSION": {
     "MAJOR": 1,
@@ -16,12 +16,12 @@
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,
-	  "MINOR": 2,
-	  "PATCH": 0
-  }
+    "MINOR": 2,
+    "PATCH": 0
+  },
   "KSP_VERSION_MAX": {
     "MAJOR": 1,
-	  "MINOR": 2,
-	  "PATCH": 99
+    "MINOR": 2,
+    "PATCH": 99
   }
 }


### PR DESCRIPTION
The version file is missing a comma, which means some automated tools can't parse it.
Now it's fixed.